### PR TITLE
add besu-admin and besu-maintainers to perms for governance

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -68,7 +68,6 @@ teams:
       - NickSneo
       - gtebrean
       - kkaur01
-      - shemnon
 repositories:
   - name: besu-errorprone-checks
     teams:

--- a/config.yaml
+++ b/config.yaml
@@ -24,11 +24,6 @@ teams:
       - garyschulte
       - jframe
       - macfarla
-    members:
-      - ConsensysOps
-      - non-fungible-nelson
-      - cdivitotawela
-      - kkaur01
   - name: besu-docs-maintainers
     maintainers:
       - bgravenorst
@@ -46,16 +41,15 @@ teams:
     members:
       - Gabriel-Trintinalia
       - ahamlat
-      - ajsutton
-      - antonydenyer
-      - atoulme
+      - cdivitotawela
       - daniellehrner
       - diega
-      - gezero
       - gfukushima
       - jflo
       - joshuafernandes
+      - lu-pinto
       - lucassaldanha
+      - Matilda-Clerke
       - matkt
       - matthew1001
       - mbaxter
@@ -65,18 +59,16 @@ teams:
   - name: besu-triage
     maintainers:
       - macfarla
-      - non-fungible-nelson
+      - jflo
+      - jframe
     members:
+      - ajsutton
+      - antonydenyer
+      - atoulme
       - NickSneo
-      - cdivitotawela
-      - cloudspores
-      - ensi321
       - gtebrean
       - kkaur01
-      - lu-pinto
-      - m4sterbunny
-      - Matilda-Clerke
-      - matthew1001
+      - shemnon
 repositories:
   - name: besu-errorprone-checks
     teams:


### PR DESCRIPTION
Propose besu-admin has maintain perms, and besu-maintainers has write perms. This would give besu-maintainers ability to approve PRs for modifying group membership.

Note this is built on top of #4 - the relevant change is below:

```
  - name: governance
    teams:
      lf-staff: maintain
      besu-admin: maintain
      besu-maintainers: write
    visibility: public
```