### PR TITLE
besu - remove mbaxter per 8710

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -49,7 +49,6 @@ teams:
       - Matilda-Clerke
       - matkt
       - matthew1001
-      - mbaxter
       - pinges
       - pullurib
       - siladu


### PR DESCRIPTION
remove @mbaxter from besu maintainers per https://github.com/hyperledger/besu/pull/8710