### PR TITLE
Add 'mirgee' to besu-triage maintainers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -51,6 +51,7 @@ teams:
       - pinges
       - siladu
       - usmansaleem
+      - mirgee
   - name: besu-triage
     maintainers:
       - macfarla
@@ -62,7 +63,6 @@ teams:
       - NickSneo
       - gtebrean
       - kkaur01
-      - mirgee
 repositories:
   - name: .github
     teams:


### PR DESCRIPTION
Add 'mirgee' to the maintainers list for 'besu-triage'.

ref besu PR https://github.com/besu-eth/besu/pull/10033