### PR TITLE
proposed cleanup of permissioning structure

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,56 @@
+# besu-eth CLOWarden configuration
+# Changes via PR to this repo; CLOWarden validates and reconciles.
+
 teams:
+
+  - name: contributors
+    maintainers:
+      - jframe
+      - jflo
+      - macfarla
+      - kkaur01
+    members:
+      - <contributor1>
+      - <contributor2>
+
+  - name: maintainers
+    maintainers:
+      - jframe
+      - jflo
+      - macfarla
+      - kkaur01
+    members:
+      - ahamlat
+      - daniellehrner
+      - diega
+      - fab-10
+      - gabriel-trintinalia
+      - garyschulte
+      - gfukushima
+      - lu-pinto
+      - lucassaldanha
+      - Matilda-Clerke
+      - matkt
+      - matthew1001
+      - mirgee
+      - pinges
+      - siladu
+      - usmansaleem
+    formation:
+      - contributors         # maintainers inherits all contributors
+
+  - name: org-admins
+    maintainers:
+      - jframe
+      - jflo
+      - macfarla
+      - kkaur01
+    members:
+      - fab-10
+      - garyschulte
+      - matkt
+      - siladu
+
   - name: lf-staff
     maintainers:
       - ryjones
@@ -8,133 +60,94 @@ teams:
       - hartm
       - jwagantall
       - thelinuxfoundation
-  - name: besu-admin
+
+  - name: security
     maintainers:
-      - fab-10
-      - garyschulte
-      - macfarla
-      - matkt
-    members:
+      - jframe
       - jflo
-      - jframe
-      - siladu
-  - name: besu-contributors
-    maintainers:
-      - garyschulte
-      - jframe
       - macfarla
-  - name: besu-docs-maintainers
+      - kkaur01
+    members:
+      - fab-10
+      - siladu
+      - garyschulte
+
+  - name: docs-maintainers
     maintainers:
-      - bgravenorst
-      - joshuafernandes
+      - jframe
+      - jflo
+      - macfarla
+      - kkaur01
     members:
       - alexandratran
+      - bgravenorst
+      - joshuafernandes
       - m4sterbunny
-  - name: besu-maintainers
-    maintainers:
-      - fab-10
-      - garyschulte
-      - jframe
-      - macfarla
-    members:
-      - Gabriel-Trintinalia
-      - ahamlat
-      - daniellehrner
-      - diega
-      - gfukushima
-      - jflo
-      - lu-pinto
-      - lucassaldanha
-      - Matilda-Clerke
-      - matkt
-      - matthew1001
-      - pinges
-      - siladu
-      - usmansaleem
-      - mirgee
-  - name: besu-triage
-    maintainers:
-      - macfarla
-      - jflo
-      - jframe
-    members:
-      - ajsutton
-      - antonydenyer
-      - NickSneo
-      - gtebrean
-      - kkaur01
+
 repositories:
-  - name: .github
-    teams:
-      lf-staff: maintain
-      besu-admin: maintain
-      besu-maintainers: write
-    visibility: public
+
+  # Core client — highest-value repo
   - name: besu
     teams:
-      besu-admin: admin
-      besu-contributors: write
-      besu-docs-maintainers: triage
-      besu-maintainers: maintain
-      besu-triage: triage
-    visibility: public
-  - name: besu-docs
-    teams:
-      besu-admin: admin
-      besu-contributors: write
-      besu-docs-maintainers: maintain
-      besu-maintainers: maintain
-      besu-triage: read
-    visibility: public
+      org-admins: admin
+      maintainers: maintain
+      contributors: triage
+
+  # Native libraries (compiled crypto/perf deps)
   - name: besu-native
     teams:
-      besu-admin: admin
-      besu-contributors: write
-      besu-docs-maintainers: read
-      besu-maintainers: maintain
-      besu-triage: read
-    visibility: public
+      org-admins: admin
+      maintainers: maintain
+      contributors: triage
+
+  # Static analysis / build tooling
   - name: besu-errorprone-checks
     teams:
-      besu-admin: admin
-      besu-contributors: write
-      besu-docs-maintainers: read
-      besu-maintainers: maintain
-      besu-triage: read
-    visibility: public
-  - name: besu-stateless
+      org-admins: admin
+      maintainers: maintain
+      contributors: triage
+
+  # Documentation site
+  - name: besu-docs
     teams:
-      besu-admin: admin
-      besu-contributors: write
-      besu-docs-maintainers: read
-      besu-maintainers: maintain
-      besu-triage: read
-    visibility: public
-  - name: besu-hsm-plugin
-    teams:
-      besu-admin: admin
-      besu-contributors: write
-      besu-docs-maintainers: read
-      besu-maintainers: maintain
-      besu-triage: read
-    visibility: public
+      org-admins: admin
+      maintainers: maintain
+      docs-maintainers: maintain
+      contributors: triage
+
+  # Org governance (CLOWarden config lives here)
   - name: governance
     teams:
+      org-admins: admin
+      maintainers: maintain
       lf-staff: maintain
-      besu-admin: maintain
-      besu-maintainers: write
-    visibility: public
-  - name: homebrew-besu
+      # contributors intentionally excluded — governance changes are maintainer-only
+
+  # Org-wide GitHub defaults (.github/FUNDING.yml, issue templates, etc.)
+  - name: .github
     teams:
-      besu-admin: admin
-      besu-contributors: write
-      besu-docs-maintainers: read
-      besu-maintainers: maintain
-      besu-triage: read
-    visibility: public
+      org-admins: admin
+      maintainers: maintain
+      lf-staff: maintain
+
+  # Wiki / knowledge base
   - name: wiki
     teams:
+      org-admins: admin
+      maintainers: maintain
       lf-staff: maintain
-      besu-admin: maintain
-      besu-maintainers: write
-    visibility: public
+      docs-maintainers: write
+      contributors: write
+
+  # Homebrew tap for Besu
+  - name: homebrew-besu
+    teams:
+      org-admins: admin
+      maintainers: maintain
+
+  # Security vulnerability tracking — restricted
+  - name: vectors
+    teams:
+      org-admins: admin
+      security: write
+      # maintainers and contributors intentionally excluded

--- a/config.yaml
+++ b/config.yaml
@@ -107,7 +107,6 @@ repositories:
   - name: besu
     teams:
       besu-admin: admin
-      besu-contributors: write
       besu-docs-maintainers: triage
       besu-maintainers: maintain
       besu-triage: triage
@@ -115,7 +114,6 @@ repositories:
   - name: besu-docs
     teams:
       besu-admin: admin
-      besu-contributors: write
       besu-docs-maintainers: admin
       besu-maintainers: maintain
       besu-triage: read
@@ -124,14 +122,12 @@ repositories:
     teams:
       org-admins: admin
       maintainers: maintain
-      contributors: triage
 
   # Static analysis / build tooling
   - name: besu-errorprone-checks
     teams:
       org-admins: admin
       maintainers: maintain
-      contributors: triage
 
   # Org governance (CLOWarden config lives here)
   - name: governance
@@ -155,7 +151,6 @@ repositories:
       maintainers: maintain
       lf-staff: maintain
       docs-maintainers: write
-      contributors: write
 
   # Homebrew tap for Besu
   - name: homebrew-besu

--- a/config.yaml
+++ b/config.yaml
@@ -3,16 +3,6 @@
 
 teams:
 
-  - name: contributors
-    maintainers:
-      - jframe
-      - jflo
-      - macfarla
-      - kkaur01
-    members:
-      - <contributor1>
-      - <contributor2>
-
   - name: maintainers
     maintainers:
       - jframe
@@ -36,8 +26,6 @@ teams:
       - pinges
       - siladu
       - usmansaleem
-    formation:
-      - contributors         # maintainers inherits all contributors
 
   - name: org-admins
     maintainers:
@@ -143,14 +131,6 @@ repositories:
     teams:
       org-admins: admin
       maintainers: maintain
-      contributors: triage
-
-  # Documentation site
-  - name: besu-docs
-    teams:
-      org-admins: admin
-      maintainers: maintain
-      docs-maintainers: maintain
       contributors: triage
 
   # Org governance (CLOWarden config lives here)

--- a/config.yaml
+++ b/config.yaml
@@ -113,14 +113,14 @@ repositories:
   # Core client — highest-value repo
   - name: besu
     teams:
-      repo-admin: admin
+      repo-admins: admin
       docs-maintainers: triage
       besu-maintainers: maintain
       besu-triage: triage
     visibility: public
   - name: besu-docs
     teams:
-      repo-admin: admin
+      repo-admins: admin
       docs-maintainers: admin
       besu-maintainers: maintain
       besu-triage: read

--- a/config.yaml
+++ b/config.yaml
@@ -91,7 +91,6 @@ repositories:
     teams:
       org-admins: admin
       maintainers: maintain
-      contributors: triage
       security: write
       security-managers: read
 
@@ -99,7 +98,6 @@ repositories:
     teams:
       org-admins: admin
       maintainers: maintain
-      contributors: triage
       security: write
       security-managers: read
   
@@ -107,7 +105,6 @@ repositories:
     teams:
       org-admins: admin
       maintainers: maintain
-      contributors: triage
       security: write
       security-managers: read
       
@@ -115,7 +112,6 @@ repositories:
     teams:
       org-admins: admin
       maintainers: maintain
-      contributors: triage
       security: write
       security-managers: read
 
@@ -123,7 +119,6 @@ repositories:
     teams:
       org-admins: admin
       maintainers: maintain
-      contributors: triage
       security: write
       security-managers: read
 
@@ -132,7 +127,6 @@ repositories:
       org-admins: admin
       maintainers: maintain
       docs-maintainers: maintain
-      contributors: triage
       security: write
       security-managers: read
 
@@ -156,7 +150,6 @@ repositories:
       maintainers: maintain
       lf-staff: maintain
       docs-maintainers: write
-      contributors: write
       security: write
       security-managers: read
 

--- a/config.yaml
+++ b/config.yaml
@@ -185,6 +185,7 @@ repositories:
 
   # Security vulnerability tracking — restricted
   - name: vectors
+    visibility: private
     teams:
       org-admins: admin
       security: write

--- a/config.yaml
+++ b/config.yaml
@@ -67,11 +67,8 @@ teams:
       - macfarla
       - kkaur01
     members:
-      - SeanBohan
-      - davidwboswell
+      - ryjones
       - hartm
-      - jwagantall
-      - thelinuxfoundation
 
   - name: docs-maintainers
     maintainers:

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,56 @@
+# besu-eth CLOWarden configuration
+# Changes via PR to this repo; CLOWarden validates and reconciles.
+
 teams:
+
+  - name: contributors
+    maintainers:
+      - jframe
+      - jflo
+      - macfarla
+      - kkaur01
+    members:
+      - <contributor1>
+      - <contributor2>
+
+  - name: maintainers
+    maintainers:
+      - jframe
+      - jflo
+      - macfarla
+      - kkaur01
+    members:
+      - ahamlat
+      - daniellehrner
+      - diega
+      - fab-10
+      - gabriel-trintinalia
+      - garyschulte
+      - gfukushima
+      - lu-pinto
+      - lucassaldanha
+      - Matilda-Clerke
+      - matkt
+      - matthew1001
+      - mirgee
+      - pinges
+      - siladu
+      - usmansaleem
+    formation:
+      - contributors         # maintainers inherits all contributors
+
+  - name: org-admins
+    maintainers:
+      - jframe
+      - jflo
+      - macfarla
+      - kkaur01
+    members:
+      - fab-10
+      - garyschulte
+      - matkt
+      - siladu
+
   - name: lf-staff
     maintainers:
       - ryjones
@@ -8,25 +60,24 @@ teams:
       - hartm
       - jwagantall
       - thelinuxfoundation
-  - name: besu-admin
+
+  - name: security
     maintainers:
-      - fab-10
-      - garyschulte
-      - macfarla
-      - matkt
-    members:
+      - jframe
       - jflo
-      - jframe
-      - siladu
-  - name: besu-contributors
-    maintainers:
-      - garyschulte
-      - jframe
       - macfarla
-  - name: besu-docs-maintainers
+      - kkaur01
+    members:
+      - fab-10
+      - siladu
+      - garyschulte
+
+  - name: docs-maintainers
     maintainers:
-      - bgravenorst
-      - joshuafernandes
+      - jframe
+      - jflo
+      - macfarla
+      - kkaur01
     members:
       - alexandratran
   - name: besu-maintainers
@@ -63,12 +114,8 @@ teams:
       - gtebrean
       - kkaur01
 repositories:
-  - name: .github
-    teams:
-      lf-staff: maintain
-      besu-admin: maintain
-      besu-maintainers: write
-    visibility: public
+
+  # Core client — highest-value repo
   - name: besu
     teams:
       besu-admin: admin
@@ -87,53 +134,58 @@ repositories:
     visibility: public
   - name: besu-native
     teams:
-      besu-admin: admin
-      besu-contributors: write
-      besu-docs-maintainers: read
-      besu-maintainers: maintain
-      besu-triage: read
-    visibility: public
+      org-admins: admin
+      maintainers: maintain
+      contributors: triage
+
+  # Static analysis / build tooling
   - name: besu-errorprone-checks
     teams:
-      besu-admin: admin
-      besu-contributors: write
-      besu-docs-maintainers: read
-      besu-maintainers: maintain
-      besu-triage: read
-    visibility: public
-  - name: besu-stateless
+      org-admins: admin
+      maintainers: maintain
+      contributors: triage
+
+  # Documentation site
+  - name: besu-docs
     teams:
-      besu-admin: admin
-      besu-contributors: write
-      besu-docs-maintainers: read
-      besu-maintainers: maintain
-      besu-triage: read
-    visibility: public
-  - name: besu-hsm-plugin
-    teams:
-      besu-admin: admin
-      besu-contributors: write
-      besu-docs-maintainers: read
-      besu-maintainers: maintain
-      besu-triage: read
-    visibility: public
+      org-admins: admin
+      maintainers: maintain
+      docs-maintainers: maintain
+      contributors: triage
+
+  # Org governance (CLOWarden config lives here)
   - name: governance
     teams:
+      org-admins: admin
+      maintainers: maintain
       lf-staff: maintain
-      besu-admin: maintain
-      besu-maintainers: write
-    visibility: public
-  - name: homebrew-besu
+      # contributors intentionally excluded — governance changes are maintainer-only
+
+  # Org-wide GitHub defaults (.github/FUNDING.yml, issue templates, etc.)
+  - name: .github
     teams:
-      besu-admin: admin
-      besu-contributors: write
-      besu-docs-maintainers: read
-      besu-maintainers: maintain
-      besu-triage: read
-    visibility: public
+      org-admins: admin
+      maintainers: maintain
+      lf-staff: maintain
+
+  # Wiki / knowledge base
   - name: wiki
     teams:
+      org-admins: admin
+      maintainers: maintain
       lf-staff: maintain
-      besu-admin: maintain
-      besu-maintainers: write
-    visibility: public
+      docs-maintainers: write
+      contributors: write
+
+  # Homebrew tap for Besu
+  - name: homebrew-besu
+    teams:
+      org-admins: admin
+      maintainers: maintain
+
+  # Security vulnerability tracking — restricted
+  - name: vectors
+    teams:
+      org-admins: admin
+      security: write
+      # maintainers and contributors intentionally excluded

--- a/config.yaml
+++ b/config.yaml
@@ -27,7 +27,7 @@ teams:
       - siladu
       - usmansaleem
 
-  - name: org-admins
+  - name: repo-admins
     maintainers:
       - jframe
       - jflo
@@ -107,32 +107,32 @@ repositories:
   - name: besu
     teams:
       besu-admin: admin
-      besu-docs-maintainers: triage
+      docs-maintainers: triage
       besu-maintainers: maintain
       besu-triage: triage
     visibility: public
   - name: besu-docs
     teams:
       besu-admin: admin
-      besu-docs-maintainers: admin
+      docs-maintainers: admin
       besu-maintainers: maintain
       besu-triage: read
     visibility: public
   - name: besu-native
     teams:
-      org-admins: admin
+      repo-admins: admin
       maintainers: maintain
 
   # Static analysis / build tooling
   - name: besu-errorprone-checks
     teams:
-      org-admins: admin
+      repo-admins: admin
       maintainers: maintain
 
   # Org governance (CLOWarden config lives here)
   - name: governance
     teams:
-      org-admins: admin
+      repo-admins: admin
       maintainers: maintain
       lf-staff: maintain
       # contributors intentionally excluded — governance changes are maintainer-only
@@ -147,7 +147,7 @@ repositories:
   # Wiki / knowledge base
   - name: wiki
     teams:
-      org-admins: admin
+      repo-admins: admin
       maintainers: maintain
       lf-staff: maintain
       docs-maintainers: write
@@ -155,7 +155,7 @@ repositories:
   # Homebrew tap for Besu
   - name: homebrew-besu
     teams:
-      org-admins: admin
+      repo-admins: admin
       maintainers: maintain
 
   # Security vulnerability tracking — restricted

--- a/config.yaml
+++ b/config.yaml
@@ -27,6 +27,13 @@ teams:
       - siladu
       - usmansaleem
 
+  - name: org-admins
+    maintainers:
+      - jframe
+      - jflo
+      - macfarla
+      - kkaur01
+
   - name: repo-admins
     maintainers:
       - jframe
@@ -106,14 +113,14 @@ repositories:
   # Core client — highest-value repo
   - name: besu
     teams:
-      besu-admin: admin
+      repo-admin: admin
       docs-maintainers: triage
       besu-maintainers: maintain
       besu-triage: triage
     visibility: public
   - name: besu-docs
     teams:
-      besu-admin: admin
+      repo-admin: admin
       docs-maintainers: admin
       besu-maintainers: maintain
       besu-triage: read


### PR DESCRIPTION
## Summary

Restructures the CLOWarden configuration around generic role-named teams (`maintainers`, `org-admins`, `security`, `docs-maintainers`, `lf-staff`) instead of repo-prefixed teams, and refreshes the maintainer roster to match `MAINTAINERS.md`.

## Team changes

**Renamed / restructured:**
- `besu-admin` → `org-admins`
- `besu-maintainers` → `maintainers`
- `besu-docs-maintainers` → `docs-maintainers`
- `besu-triage` removed (contributors team replaces it)

**Roster updates:**
- `org-admins` maintainers: `jframe`, `jflo`, `macfarla`, `kkaur01`; members: `fab-10`, `garyschulte`, `matkt`, `siladu` (admin access preserved for prior besu-admin members; **kkaur01 promoted from triage to admin**)
- `maintainers` aligned with the Active Maintainers list in `MAINTAINERS.md` (19 people, with `mirgee` newly added)
- New `security` team (jframe/jflo/macfarla/kkaur01 admins; fab-10/siladu/garyschulte members) 
- New `docs-maintainers` team preserves the prior docs-maintainer roster (alexandratran, bgravenorst, joshuafernandes, m4sterbunny)
- `lf-staff` retained at prior access levels (ryjones + 5 LF members; maintain on `.github`, `governance`, `wiki`)

**No longer in CLOWarden:**
- Triage-only members `ajsutton`, `antonydenyer`, `NickSneo`, `gtebrean` (not on the Active Maintainers list)

## Repository changes

- Repo grants migrated to use new team names; access levels for active maintainers and LF staff preserved
- `homebrew-besu` retained but with tighter access (org-admins admin, maintainers maintain only — contributors/docs/triage grants intentionally dropped)
- `visibility: public` keys removed (CLOWarden manages access, not visibility)

## Notable access changes

| User(s) | Change |
|---|---|
| kkaur01 | triage → **admin** (org-admins) |
| mirgee | not in CLOWarden → maintainer |
| ajsutton, antonydenyer, NickSneo, gtebrean | triage on besu repos → **removed** |
| bgravenorst, joshuafernandes | docs-maintainers team-maintainer role → docs-maintainers member (repo access on besu-docs preserved at `maintain`) |

