### PR TITLE
Fix capitalization of Gabriel-Trintinalia

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -14,7 +14,7 @@ teams:
       - daniellehrner
       - diega
       - fab-10
-      - gabriel-trintinalia
+      - Gabriel-Trintinalia
       - garyschulte
       - gfukushima
       - lu-pinto


### PR DESCRIPTION
The account name is Gabriel-Trintinalia - having it in the wrong case is causing [team flapping every hour](https://clowarden.io/audit/?organization=besu-eth&page=1).