### PR TITLE
fix: remove stray backtick breaking triage-delegation GraphQL mutation

### DIFF
--- a/scripts/triage-delegation.js
+++ b/scripts/triage-delegation.js
@@ -284,7 +284,7 @@ async function getIssueOtherProjects(issueNodeId, triageProjectId, cachedProject
 
 async function updateItemStatus(projectId, itemId, fieldId, optionId) {
   await graphql(
-    `mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: ID!) {`
+    `mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: ID!) {
       updateProjectV2ItemFieldValue(input: {
         projectId: $projectId
         itemId: $itemId


### PR DESCRIPTION
The updateItemStatus mutation string had a stray backtick right after the opening brace, which closed the template literal early and produced a SyntaxError at module load, failing the Triage Delegation workflow.