### PR TITLE
Revert "Update team members in config.yaml"

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -63,20 +63,9 @@ teams:
       - macfarla
       - kkaur01
     members:
-      - ahamlat
-      - daniellehrner
-      - diega
       - fab-10
-      - Gabriel-Trintinalia
-      - garyschulte
-      - gfukushima
-      - joshuafernandes
-      - lu-pinto
-      - lucassaldanha
-      - matkt
-      - pinges
       - siladu
-      - usmansaleem
+      - garyschulte
 
   - name: docs-maintainers
     maintainers:


### PR DESCRIPTION
sec team shouldn't likely be this broad, and should not include ex-maintainer diega